### PR TITLE
Support aarch32 without requiring codegen flags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ pub fn hvc32(function: u32, args: [u32; 7]) -> [u32; 8] {
             "mov {tmp7}, r7",
             "mov r6, {r6_value}",
             "mov r7, {r7_value}",
-            "hvc #0",
+            ".inst 0xe1400070", // hvc #0, without requiring -C target-feature=+virtualization
             "mov {r6_value}, r6",
             "mov {r7_value}, r7",
             "mov r6, {tmp6}",
@@ -144,7 +144,7 @@ pub fn smc32(function: u32, args: [u32; 7]) -> [u32; 8] {
             "mov {tmp7}, r7",
             "mov r6, {r6_value}",
             "mov r7, {r7_value}",
-            "smc #0",
+            ".inst 0xe1600070", // smc #0, without requiring -C target-feature=+trustzone
             "mov {r6_value}, r6",
             "mov {r7_value}, r7",
             "mov r6, {tmp6}",


### PR DESCRIPTION
As noted in https://github.com/google/smccc/pull/10, for aarch32, using the `hvc` and `smc` instructions in `asm!()` requires `-C target-feature=+virtualization,+trustzone`. By replacing `hvc #0` and `smc #0` with their corresponding opcodes (one instance each), we can support aarch32 without requiring these codegen flags.

This workaround, of course, comes at the cost of making those two lines of code more opaque. Up to the maintainers whether they think that's worth improving this crate's ease of use.

My use case is for a bootloader I'm shipping in source form as part of https://github.com/seL4/rust-sel4. For my use case, requiring downstream users to supply that `-C` argument to rustc via `RUSTFLAGS` isn't worth the benefits of using this crate in my bootloader's implementation.